### PR TITLE
Proposing fix to resolve infinite loop in parsenumber()

### DIFF
--- a/GcodeCNCDemo2Axis/GcodeCNCDemo2Axis.ino
+++ b/GcodeCNCDemo2Axis/GcodeCNCDemo2Axis.ino
@@ -184,7 +184,7 @@ float parsenumber(char code,float val) {
     if(*ptr==code) {
       return atof(ptr+1);
     }
-    ptr=strchr(ptr,' ');
+    ptr=strchr(ptr,' ')+1;
   }
   return val;
 } 


### PR DESCRIPTION
Proposing change to Line 187. 
ptr=strchr(ptr,' ')+1;

This should fix an infinite loop condition that can be entered when parsing for the second code embedded in a command.
