### PR TITLE
Fix serialBuffer, parseNumber errors and add Stepper.h driver

### DIFF
--- a/GcodeCNCDemo2Axis/GcodeCNCDemo2Axis.ino
+++ b/GcodeCNCDemo2Axis/GcodeCNCDemo2Axis.ino
@@ -176,9 +176,9 @@ void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parseNumber(char code,float val) {
-  char *ptr=serialBuffer;  // start at the beginning of buffer
-  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
+float parsenumber(char code,float val) {
+  char *ptr=buffer;  // start at the beginning of buffer
+  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)buffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,
       return atof(ptr+1);  // convert the digits that follow into a float and return it
     }

--- a/GcodeCNCDemo2Axis/PassThroughStep.ino
+++ b/GcodeCNCDemo2Axis/PassThroughStep.ino
@@ -1,0 +1,73 @@
+//------------------------------------------------------------------------------
+// 2 Axis CNC Demo
+// dan@marginallycelver.com 2013-08-30
+// modified by lsahidin@yahoo.com added HG7881 stepper controller
+// modified by drf5na@gmail.com added a simple pass-through Stepper.h driver
+//------------------------------------------------------------------------------
+// Copyright at end of file.
+// please see http://www.github.com/MarginallyClever/GcodeCNCDemo for more information.
+
+// Warning.
+// * to reduce and avoid overheat on HG7881, use M18 after every G00, G01, G02, G03 on Gcode * \\
+
+#if CONTROLLER == PASS_STEP
+
+//------------------------------------------------------------------------------
+// INCLUDES
+//------------------------------------------------------------------------------
+#include <Stepper.h> // https://github.com/arduino-libraries/Stepper/blob/master/src/Stepper.h
+
+
+//------------------------------------------------------------------------------
+// GLOBALS
+//------------------------------------------------------------------------------
+// Initialize Stepper.h stepper controller
+// Stepper.h motor(Step, pinA_IA, pinA_IB, pinB_IA, pin_B_IB);
+Stepper m1((int)STEPS_PER_TURN, 6,7,8,9);
+Stepper m2((int)STEPS_PER_TURN, 5,4,3,2);
+
+
+//------------------------------------------------------------------------------
+// METHODS
+//------------------------------------------------------------------------------
+
+void m1step(int dir) {
+    m1.step(dir);
+}
+
+void m2step(int dir) {
+    m2.step(dir);
+}
+
+void disable() {
+    //m1.release();
+    //m2.release();
+}
+
+
+void setup_controller() {
+    ;
+    m1.setSpeed(100);
+    m2.setSpeed(100);
+}
+
+
+#endif  // CONTROLLER == PASS_STEP
+/**
+* This file is part of GcodeCNCDemo.
+*
+* GcodeCNCDemo is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* GcodeCNCDemo is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+

--- a/GcodeCNCDemo2Axis/config.h
+++ b/GcodeCNCDemo2Axis/config.h
@@ -15,9 +15,10 @@
 #define AMS1 (1)
 #define AMS2 (2)
 #define HG7881 (3) // HG7881 Stepper Driver
+#define PASS_STEP (4) // pass-through 4 wire Stepper.h driver
 
 // change this line to select a different control board for your CNC.
-#define CONTROLLER AMS1
+#define CONTROLLER PASS_STEP
 
 
 #define VERSION        (1)  // firmware version

--- a/GcodeCNCDemo4axisV2/GcodeCNCDemo4AxisV2.ino
+++ b/GcodeCNCDemo4axisV2/GcodeCNCDemo4AxisV2.ino
@@ -254,9 +254,9 @@ static void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parseNumber(char code,float val) {
-  char *ptr=serialBuffer;  // start at the beginning of buffer
-  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
+float parsenumber(char code,float val) {
+  char *ptr=buffer;  // start at the beginning of buffer
+  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)buffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,
       return atof(ptr+1);  // convert the digits that follow into a float and return it
     }

--- a/GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino
+++ b/GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino
@@ -53,7 +53,7 @@ Axis a[NUM_AXIES];  // for line()
 Axis atemp;  // for line()
 Motor motors[NUM_AXIES];
 
-char buffer[MAX_BUF];  // where we store the message until we get a ';'
+char serialBuffer[MAX_BUF];  // where we store the message until we get a ';'
 int sofar;  // how much is in the buffer
 
 // speeds
@@ -272,7 +272,7 @@ static void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parseNumber(char code,float val) {
+float parsenumber(char code,float val) {
   char *ptr=serialBuffer;  // start at the beginning of buffer
   while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,
@@ -476,10 +476,10 @@ void loop() {
   while(Serial.available() > 0) {  // if something is available
     char c=Serial.read();  // get it
     Serial.print(c);  // repeat it back so I know you got the message
-    if(sofar<MAX_BUF-1) buffer[sofar++]=c;  // store it
+    if(sofar<MAX_BUF-1) serialBuffer[sofar++]=c;  // store it
     if(c=='\n') {
       // entire message received
-      buffer[sofar]=0;  // end the buffer so string functions work right
+      serialBuffer[sofar]=0;  // end the buffer so string functions work right
       Serial.print(F("\r\n"));  // echo a return character for humans
       processCommand();  // do something with the command
       ready();

--- a/GcodeCNCDemo6AxisV2/GcodeCNCDemo6AxisV2.ino
+++ b/GcodeCNCDemo6AxisV2/GcodeCNCDemo6AxisV2.ino
@@ -267,9 +267,9 @@ static void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parseNumber(char code,float val) {
-  char *ptr=serialBuffer;  // start at the beginning of buffer
-  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
+float parsenumber(char code,float val) {
+  char *ptr=buffer;  // start at the beginning of buffer
+  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)buffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,
       return atof(ptr+1);  // convert the digits that follow into a float and return it
     }


### PR DESCRIPTION
This is a PR to fix https://github.com/MarginallyClever/GcodeCNCDemo/issues/29 and parts of https://github.com/MarginallyClever/GcodeCNCDemo/issues/28

It:

* Changes the name of serialBuffer to buffer
* Changes parseNumber to parsenumber
* Adds a Stepper.h driver file

These changes make it compile for Arduino and the Wokwi simulator.

See https://wokwi.com/projects/327748577668366932 

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/2236516/161327043-0eefca30-fb1c-4e10-a52e-2ec4e27362ff.png">
