### PR TITLE
Complete https://github.com/MarginallyClever/GcodeCNCDemo/pull/34

### DIFF
--- a/GcodeCNCDemo4axisV2/GcodeCNCDemo4AxisV2.ino
+++ b/GcodeCNCDemo4axisV2/GcodeCNCDemo4AxisV2.ino
@@ -254,9 +254,9 @@ static void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parsenumber(char code,float val) {
-  char *ptr=buffer;  // start at the beginning of buffer
-  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)buffer+sofar) {  // walk to the end
+float parseNumber(char code,float val) {
+  char *ptr=serialBuffer;  // start at the beginning of buffer
+  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,
       return atof(ptr+1);  // convert the digits that follow into a float and return it
     }

--- a/GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino
+++ b/GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino
@@ -272,7 +272,7 @@ static void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parsenumber(char code,float val) {
+float parseNumber(char code,float val) {
   char *ptr=serialBuffer;  // start at the beginning of buffer
   while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,

--- a/GcodeCNCDemo6AxisV2/GcodeCNCDemo6AxisV2.ino
+++ b/GcodeCNCDemo6AxisV2/GcodeCNCDemo6AxisV2.ino
@@ -270,9 +270,9 @@ static void arc(float cx,float cy,float x,float y,float dir) {
  * @input code the character to look for.
  * @input val the return value if /code/ is not found.
  **/
-float parsenumber(char code,float val) {
-  char *ptr=buffer;  // start at the beginning of buffer
-  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)buffer+sofar) {  // walk to the end
+float parseNumber(char code,float val) {
+  char *ptr=serialBuffer;  // start at the beginning of buffer
+  while((long)ptr > 1 && (*ptr) && (long)ptr < (long)serialBuffer+sofar) {  // walk to the end
     if(*ptr==code) {  // if you find code on your walk,
       return atof(ptr+1);  // convert the digits that follow into a float and return it
     }


### PR DESCRIPTION
This completes the regularization to parseNumber and serialBuffer in all files.

I had changed most of the parseNumber commands over, but I think I messed up some git+github transferring and missed the last part in pushing what I had tested locally up to github and into  https://github.com/MarginallyClever/GcodeCNCDemo/pull/34

This one really works.  Really.

GcodeCNCDemo4axisV2/GcodeCNCDemo4AxisV2.ino
```
Sketch uses 14776 bytes (5%) of program storage space. Maximum is 253952 bytes.
Global variables use 886 bytes (10%) of dynamic memory, leaving 7306 bytes for local variables. Maximum is 8192 bytes.
```

GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino

```
Sketch uses 11962 bytes (4%) of program storage space. Maximum is 253952 bytes.
Global variables use 488 bytes (5%) of dynamic memory, leaving 7704 bytes for local variables. Maximum is 8192 bytes.
```

GcodeCNCDemo6AxisV2/GcodeCNCDemo6AxisV2.ino
```
Sketch uses 14776 bytes (5%) of program storage space. Maximum is 253952 bytes.
Global variables use 886 bytes (10%) of dynamic memory, leaving 7306 bytes for local variables. Maximum is 8192 bytes.

```