### PR TITLE
Update GcodeCNCDemo6AxisRumba.ino to F<200step/sec

### DIFF
--- a/GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino
+++ b/GcodeCNCDemo6AxisRumba/GcodeCNCDemo6AxisRumba.ino
@@ -163,6 +163,10 @@ void line(float newx,float newy,float newz,float newu,float newv,float neww) {
   long dt = MAX_FEEDRATE / 5000;
   long accel = 1;
   long steps_to_accel = dt - step_delay;
+  if(steps_to_accel < 0){
+    steps_to_accel = 0;
+    dt = step_delay;
+  }
   if(steps_to_accel > maxsteps/2 ) 
     steps_to_accel = maxsteps/2;
     


### PR DESCRIPTION
Protect against negative dt and steps_to_accelerate when using feedrates less than MAX_FEEDRATE/5000= 200steps/sec by setting dt directly.

Simulation at https://wokwi.com/projects/327981866411885138 has this patch, and works with slow feed rates down to the minimum F0.01 steps/sec.
